### PR TITLE
fix: 비회원이 댓글 조회 시, 매니지 버튼 검증 로직 오류 수정

### DIFF
--- a/src/main/resources/static/js/libs/comment/Comment.js
+++ b/src/main/resources/static/js/libs/comment/Comment.js
@@ -246,9 +246,13 @@ export class Comment {
 
             Comment.DOM.placeData(clonedUnit, data);
 
-            if (AuthChecker.hasAuth && Comment.Utility.isWriterOf(data)) {
-                Comment.DOM.addCommentManageButton(clonedUnit, data);
+            if (AuthChecker.hasAuth) {
+                return;
             }
+
+            if (Comment.Utility.isWriterOf(data)) {
+                Comment.DOM.addCommentManageButton(clonedUnit, data);
+            }   
 
             if (firstComment !== undefined) {
                 commentContainer.insertBefore(clonedUnit, firstComment);
@@ -265,7 +269,11 @@ export class Comment {
             Comment.DOM.placeData(clonedUnit, data);
             commentContainer.appendChild(clonedUnit);
 
-            if (AuthChecker.hasAuth && Comment.Utility.isWriterOf(data)) {
+            if (AuthChecker.hasAuth) {
+                return;
+            } 
+            
+            if (Comment.Utility.isWriterOf(data)) {
                 Comment.DOM.addCommentManageButton(clonedUnit, data);
             }
         }


### PR DESCRIPTION
* 인증 여부와, 댓글 소유 여부는 서로 다른 수준에서 걸러야 오류를 일으키지 않음. 
  비회원의 경우, 인증 여부 수준에서 거르고, 
  댓글 소유 여부를 따질 필요는 없음. (인증 정보가 있어야 소유 여부 판별 가능)